### PR TITLE
#84 - Validation endpoint for imported structured query

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v2/QueryHandlerRestController.java
@@ -210,6 +210,11 @@ public class QueryHandlerRestController {
     return new ResponseEntity<>(queryContent, HttpStatus.OK);
   }
 
+  @PostMapping("/validate")
+  public ResponseEntity<Object> validateStructuredQuery(@Valid @RequestBody StructuredQuery query) {
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
   private boolean hasAccess(Long queryId, Authentication authentication) {
     Set<String> roles = authentication.getAuthorities().stream()
         .map(GrantedAuthority::getAuthority).collect(Collectors.toSet());


### PR DESCRIPTION
- add validation endpoint for queries under /api/v2/query/validate
- close #84 