### PR TITLE
#523  - Admin user should be able to read all queries

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/dataquery/DataquerySpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/dataquery/DataquerySpringConfig.java
@@ -15,8 +15,9 @@ public class DataquerySpringConfig {
       @Qualifier("translation") ObjectMapper jsonUtil,
       DataqueryRepository dataqueryRepository,
       DataqueryCsvExportService dataqueryCsvExportService,
-      @Value("${app.maxSavedQueriesPerUser}") Integer maxSavedQueriesPerUser
+      @Value("${app.maxSavedQueriesPerUser}") Integer maxSavedQueriesPerUser,
+      @Value("${app.keycloakAdminRole}") String keycloakAdminRole
   ) {
-    return new DataqueryHandler(jsonUtil, dataqueryRepository, dataqueryCsvExportService, maxSavedQueriesPerUser);
+    return new DataqueryHandler(jsonUtil, dataqueryRepository, dataqueryCsvExportService, maxSavedQueriesPerUser, keycloakAdminRole);
   }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -78,10 +79,10 @@ public class DataqueryHandlerRestController {
   @GetMapping(path = "/{dataqueryId}")
   public ResponseEntity<Object> getDataquery(@PathVariable(value = "dataqueryId") Long dataqueryId,
                                                  @RequestParam(value = "skip-validation", required = false, defaultValue = "false") boolean skipValidation,
-      Principal principal) {
+      Authentication authentication) {
 
     try {
-      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, principal.getName());
+      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, authentication);
       var dataqueryWithInvalidCriteria = Dataquery.builder()
               .id(dataquery.id())
               .content(
@@ -117,10 +118,10 @@ public class DataqueryHandlerRestController {
   @GetMapping(path = "/{dataqueryId}" + PATH_CRTDL)
   public ResponseEntity<Object> getDataqueryCrtdl(@PathVariable(value = "dataqueryId") Long dataqueryId,
                                              @RequestParam(value = "skip-validation", required = false, defaultValue = "false") boolean skipValidation,
-                                             Principal principal) {
+                                             Authentication authentication) {
 
     try {
-      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, principal.getName());
+      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, authentication);
       var crtdlWithInvalidCritiera = Crtdl.builder()
           .display(dataquery.content().display())
           .version(dataquery.content().version())
@@ -137,9 +138,9 @@ public class DataqueryHandlerRestController {
 
   @GetMapping(path = "/{dataqueryId}" + PATH_CRTDL, produces = "application/zip")
   public ResponseEntity<Object> getDataqueryCrtdlCsv(@PathVariable(value = "dataqueryId") Long dataqueryId,
-                                                     Principal principal) {
+                                                     Authentication authentication) {
     try {
-      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, principal.getName());
+      var dataquery = dataqueryHandler.getDataqueryById(dataqueryId, authentication);
       var zipByteArrayOutputStream = dataqueryHandler.createCsvExportZipfile(dataquery);
       HttpHeaders headers = new HttpHeaders();
       String headerValue = "attachment; filename=" + dataquery.label().toUpperCase() +  "_dataquery.zip";

--- a/src/test/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfigIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/config/WebSecurityConfigIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -148,7 +149,7 @@ class WebSecurityConfigIT {
   @Test
   @WithMockUser(username = "user", roles = "DATAPORTAL_TEST_USER")
   void getDataquery_authenticatedAllowed() throws Exception {
-    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
 
     mockMvc.perform(get(URI.create("/api/v5/query/data/1")).with(csrf()))
         .andExpect(status().isOk());
@@ -156,7 +157,7 @@ class WebSecurityConfigIT {
 
   @Test
   void getDataquery_unauthenticatedDenied() throws Exception {
-    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
     mockMvc.perform(get(URI.create("/api/v5/query/data/1")).with(csrf()))
         .andExpect(status().isUnauthorized());
   }
@@ -164,7 +165,7 @@ class WebSecurityConfigIT {
   @Test
   @WithMockUser(username = "user", roles = "DATAPORTAL_TEST_ADMIN")
   void getDataquery_adminAccessAllowed() throws Exception {
-    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+    doReturn(createDataquery(false)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
     mockMvc.perform(get(URI.create("/api/v5/query/data/1")).with(csrf()))
         .andExpect(status().isOk());
   }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestControllerIT.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -117,7 +118,7 @@ public class DataqueryHandlerRestControllerIT {
         long dataqueryId = 1L;
         var annotatedQuery = createValidAnnotatedStructuredQuery(false);
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doReturn(annotatedQuery).when(structuredQueryValidation).annotateStructuredQuery(any(StructuredQuery.class), any(Boolean.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId)).with(csrf()))
@@ -130,7 +131,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataquery_failsOnNotFound() throws Exception {
         long dataqueryId = 1;
 
-        doThrow(DataqueryException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doThrow(DataqueryException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId)).with(csrf()))
                 .andExpect(status().isNotFound());
@@ -141,7 +142,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataquery_failsOnJsonError() throws Exception {
         long dataqueryId = 1;
 
-        doThrow(JsonProcessingException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doThrow(JsonProcessingException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId)).with(csrf()))
                 .andExpect(status().isInternalServerError());
@@ -153,7 +154,7 @@ public class DataqueryHandlerRestControllerIT {
         long dataqueryId = 1L;
         var annotatedQuery = createValidAnnotatedStructuredQuery(false);
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doReturn(annotatedQuery).when(structuredQueryValidation).annotateStructuredQuery(any(StructuredQuery.class), any(Boolean.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl")).with(csrf()))
@@ -166,7 +167,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdl_failsOnNotFound() throws Exception {
         long dataqueryId = 1;
 
-        doThrow(DataqueryException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doThrow(DataqueryException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl")).with(csrf()))
             .andExpect(status().isNotFound());
@@ -177,7 +178,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdl_failsOnJsonError() throws Exception {
         long dataqueryId = 1;
 
-        doThrow(JsonProcessingException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doThrow(JsonProcessingException.class).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl")).with(csrf()))
             .andExpect(status().isInternalServerError());
@@ -188,7 +189,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdlCsv_succeeds() throws Exception {
         long dataqueryId = 1L;
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doReturn(createValidByteArrayOutputStream()).when(dataqueryHandler).createCsvExportZipfile(any(Dataquery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl"))
@@ -205,7 +206,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdlCsv_failsOnNotFound() throws Exception {
         long dataqueryId = 1;
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doThrow(DataqueryException.class).when(dataqueryHandler).createCsvExportZipfile(any(Dataquery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl"))
@@ -219,7 +220,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdlCsv_failsOnJsonError() throws Exception {
         long dataqueryId = 1;
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doThrow(JsonProcessingException.class).when(dataqueryHandler).createCsvExportZipfile(any(Dataquery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl"))
@@ -233,7 +234,7 @@ public class DataqueryHandlerRestControllerIT {
     public void testGetDataqueryCrtdlCsv_failsOnIoException() throws Exception {
         long dataqueryId = 1;
 
-        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(String.class));
+        doReturn(createValidApiDataqueryToGet(dataqueryId)).when(dataqueryHandler).getDataqueryById(any(Long.class), any(Authentication.class));
         doThrow(IOException.class).when(dataqueryHandler).createCsvExportZipfile(any(Dataquery.class));
 
         mockMvc.perform(get(URI.create(PATH_API + PATH_QUERY + PATH_DATA + "/" + dataqueryId + "/crtdl"))


### PR DESCRIPTION
- When reading a dataquery, allow access for admin users no matter if they are the creator of the query