### PR TITLE
#710 - Refactor /query/data Endpoint and Remove Obsolete /query/data/…

### DIFF
--- a/.github/scripts/post-test-query.sh
+++ b/.github/scripts/post-test-query.sh
@@ -52,7 +52,7 @@ result_location=$(echo "$response" | grep -i location | awk '{print $2}')
 sleep 5
 nr_of_pats=$(curl -v \
   --url "${result_location%?}/summary-result" \
-  --header "Authorization: Bearer $access_token" | jq '.totalNumberOfPatients')
+  --header "Authorization: Bearer $access_token" | jq '.resultSize')
 
 echo "nr of pats: $nr_of_pats"
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -94,7 +94,7 @@ public class QueryHandlerService {
         return QueryResult.builder()
             .queryId(queryId)
             .resultLines(resultLines)
-            .totalNumberOfPatients(totalMatchesInPopulation)
+            .resultSize(totalMatchesInPopulation)
             .build();
     }
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Dataquery.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Dataquery.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 
 import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 @JsonInclude(Include.NON_EMPTY)
 @Builder
@@ -16,7 +18,7 @@ public record Dataquery(
     @JsonProperty Crtdl content,
     @JsonProperty String label,
     @JsonProperty String comment,
-    @JsonProperty String lastModified,
+    @JsonProperty Timestamp lastModified,
     @JsonProperty String createdBy,
     @JsonProperty CrtdlSectionInfo ccdl,
     @JsonProperty CrtdlSectionInfo dataExtraction,
@@ -32,7 +34,7 @@ public record Dataquery(
         .comment(in.getComment())
         .createdBy(in.getCreatedBy())
         .resultSize(in.getResultSize())
-        .lastModified(in.getLastModified() == null ? null : in.getLastModified().toString())
+        .lastModified(in.getLastModified())
         .content(jsonUtil.readValue(in.getCrtdl(), Crtdl.class))
         .expiresAt(in.getExpiresAt())
         .build();

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/Query.java
@@ -12,7 +12,7 @@ public record Query(
     @JsonProperty StructuredQuery content,
     @JsonProperty String label,
     @JsonProperty String comment,
-    @JsonProperty long totalNumberOfPatients
+    @JsonProperty long resultSize
 ) {
 
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryListEntry.java
@@ -14,7 +14,7 @@ public record QueryListEntry(
     @JsonProperty String label,
     @JsonProperty String comment,
     @JsonProperty Timestamp createdAt,
-    @JsonProperty Long totalNumberOfPatients,
+    @JsonProperty Long resultSize,
     @JsonProperty Boolean isValid
 )  {
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryResult.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/api/QueryResult.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record QueryResult(
-    long totalNumberOfPatients,
+    long resultSize,
     Long queryId,
     List<QueryResultLine> resultLines
 ) {

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Dataquery.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/persistence/Dataquery.java
@@ -50,9 +50,7 @@ public class Dataquery {
     out.setId(in.id() > 0 ? in.id() : null);
     out.setLabel(in.label());
     out.setComment(in.comment());
-    if (in.lastModified() != null) {
-      out.setLastModified(Timestamp.valueOf(in.lastModified()));
-    }
+    out.setLastModified(in.lastModified());
     out.setCreatedBy(in.createdBy());
     out.setResultSize(in.resultSize());
     out.setCrtdl(jsonUtil.writeValueAsString(in.content()));

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestController.java
@@ -76,6 +76,7 @@ public class DataqueryHandlerRestController {
     return new ResponseEntity<>(dataquerySlots, httpHeaders, HttpStatus.CREATED);
   }
 
+  @Deprecated
   @GetMapping(path = "/{dataqueryId}")
   public ResponseEntity<Object> getDataquery(@PathVariable(value = "dataqueryId") Long dataqueryId,
                                                  @RequestParam(value = "skip-validation", required = false, defaultValue = "false") boolean skipValidation,
@@ -184,6 +185,7 @@ public class DataqueryHandlerRestController {
                     .isValid(true) // TODO: Add validation for that
                     .build())
                 .expiresAt(dq.expiresAt())
+                .createdBy(dq.createdBy())
                 .build()
         );
       });

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestController.java
@@ -199,7 +199,7 @@ public class FeasibilityQueryHandlerRestController {
     QueryResult queryResult = queryHandlerService.getQueryResult(queryId,
         ResultDetail.DETAILED_OBFUSCATED);
 
-    if (queryResult.totalNumberOfPatients() < privacyThresholdResults) {
+    if (queryResult.resultSize() < privacyThresholdResults) {
       var issues = FeasibilityIssues.builder()
               .issues(List.of(FeasibilityIssue.PRIVACY_RESTRICTION_RESULT_SIZE))
               .build();
@@ -256,7 +256,7 @@ public class FeasibilityQueryHandlerRestController {
     var queryResult = queryHandlerService.getQueryResult(queryId,
         ResultDetail.SUMMARY);
 
-    if (queryResult.totalNumberOfPatients() < privacyThresholdResults) {
+    if (queryResult.resultSize() < privacyThresholdResults) {
       var issues = FeasibilityIssues.builder()
               .issues(List.of(FeasibilityIssue.PRIVACY_RESTRICTION_RESULT_SIZE))
               .build();

--- a/src/main/resources/static/v3/api-docs/swagger.yaml
+++ b/src/main/resources/static/v3/api-docs/swagger.yaml
@@ -891,7 +891,7 @@ components:
           type: string
           examples:
             - this can be a longer text explaining what this query is for
-        totalNumberOfResults:
+        resultSize:
           type: integer
         content:
           type: object
@@ -940,6 +940,8 @@ components:
           format: date-time
         resultSize:
           type: integer
+        createdBy:
+          type: string
         ccdl:
           type: object
           properties:
@@ -972,7 +974,7 @@ components:
     QueryResultSummary:
       type: object
       properties:
-        totalNumberOfPatients:
+        resultSize:
           type: integer
           format: int64
         queryId:
@@ -984,7 +986,7 @@ components:
     QueryResultObfuscated:
       type: object
       properties:
-        totalNumberOfPatients:
+        resultSize:
           type: integer
           format: int64
         queryId:
@@ -996,7 +998,7 @@ components:
     QueryResult:
       type: object
       properties:
-        totalNumberOfPatients:
+        resultSize:
           type: integer
           format: int64
         queryId:

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerServiceIT.java
@@ -177,7 +177,7 @@ public class QueryHandlerServiceIT {
         var queryResult = queryHandlerService.getQueryResult(UNKNOWN_QUERY_ID, DETAILED_OBFUSCATED);
 
         assertThat(queryResult.queryId()).isEqualTo(UNKNOWN_QUERY_ID);
-        assertThat(queryResult.totalNumberOfPatients()).isZero();
+        assertThat(queryResult.resultSize()).isZero();
         assertThat(queryResult.resultLines()).isEmpty();
     }
 
@@ -221,7 +221,7 @@ public class QueryHandlerServiceIT {
 
         var queryResult = queryHandlerService.getQueryResult(queryId, SUMMARY);
 
-        assertThat(queryResult.totalNumberOfPatients()).isEqualTo(30L);
+        assertThat(queryResult.resultSize()).isEqualTo(30L);
         assertThat(queryResult.resultLines()).isEmpty();
     }
 
@@ -247,7 +247,7 @@ public class QueryHandlerServiceIT {
 
         var queryResult = queryHandlerService.getQueryResult(queryId, DETAILED_OBFUSCATED);
 
-        assertThat(queryResult.totalNumberOfPatients()).isEqualTo(30L);
+        assertThat(queryResult.resultSize()).isEqualTo(30L);
         assertThat(queryResult.resultLines()).hasSize(2);
         assertThat(queryResult.resultLines().stream().map(QueryResultLine::siteName))
             .doesNotContain(SITE_NAME_1, SITE_NAME_2);
@@ -277,7 +277,7 @@ public class QueryHandlerServiceIT {
 
         var queryResult = queryHandlerService.getQueryResult(queryId, DETAILED);
 
-        assertThat(queryResult.totalNumberOfPatients()).isEqualTo(30L);
+        assertThat(queryResult.resultSize()).isEqualTo(30L);
         assertThat(queryResult.resultLines())
             .hasSize(2)
             .contains(QueryResultLine.builder().siteName(SITE_NAME_1).numberOfPatients(10L).build(),

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/dataquery/DataqueryHandlerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/dataquery/DataqueryHandlerTest.java
@@ -25,7 +25,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.C;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
@@ -46,7 +45,7 @@ class DataqueryHandlerTest {
     public static final String CREATOR = "creator-557261";
     public static final String LABEL = "some-label";
     public static final String COMMENT = "some-comment";
-    public static final String TIME_STRING = "1969-07-20 20:17:40.0";
+    public static final String TIME_STRING = "1969-07-20T20:17:40.0";
     public static final String EXPIRY_STRING = "2063-04-05 20:17:40.0";
     private static final int MAX_QUERIES_PER_USER = 5;
     private static final String KEYCLOAK_ADMIN_ROLE = "ROLE_DATAPORTAL_TEST_ADMIN";
@@ -470,7 +469,7 @@ class DataqueryHandlerTest {
             .label(LABEL)
             .comment(COMMENT)
             .createdBy(CREATOR)
-            .lastModified(TIME_STRING)
+            .lastModified(Timestamp.valueOf(TIME_STRING))
             .build();
 
         assertThrows(DataqueryException.class, () -> dataqueryHandler.createCsvExportZipfile(dataqueryWithoutContent));
@@ -488,7 +487,7 @@ class DataqueryHandlerTest {
             .label(LABEL)
             .comment(COMMENT)
             .createdBy(CREATOR)
-            .lastModified(TIME_STRING)
+            .lastModified(Timestamp.valueOf(TIME_STRING))
             .build();
 
         assertThrows(DataqueryException.class, () -> dataqueryHandler.createCsvExportZipfile(dataqueryWithoutCohortDefinition));
@@ -501,7 +500,7 @@ class DataqueryHandlerTest {
             .comment(COMMENT)
             .content(createCrtdl(withInclusion, withExclusion, withExtraction))
             .createdBy(CREATOR)
-            .lastModified(TIME_STRING)
+            .lastModified(Timestamp.valueOf(TIME_STRING))
             .build();
     }
 
@@ -513,7 +512,7 @@ class DataqueryHandlerTest {
             .content(createCrtdl())
             .resultSize(withResult ? 123L : null)
             .createdBy(CREATOR)
-            .lastModified(TIME_STRING)
+            .lastModified(Timestamp.valueOf(TIME_STRING))
             .build();
     }
 

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingInterceptorIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/ratelimiting/RateLimitingInterceptorIT.java
@@ -321,7 +321,7 @@ public class RateLimitingInterceptorIT {
 
     return QueryResult.builder()
         .queryId(1L)
-        .totalNumberOfPatients(123L)
+        .resultSize(123L)
         .resultLines(queryResultLines)
         .build();
   }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/DataqueryHandlerRestControllerIT.java
@@ -398,7 +398,7 @@ public class DataqueryHandlerRestControllerIT {
                 .content(createCrtdl())
                 .label("TestLabel")
                 .comment("TestComment")
-                .lastModified(new Timestamp(new Date().getTime()).toString())
+                .lastModified(new Timestamp(new Date().getTime()))
                 .createdBy("someone")
                 .ccdl(CrtdlSectionInfo.builder()
                     .isValid(true)

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestControllerIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/v5/FeasibilityQueryHandlerRestControllerIT.java
@@ -310,16 +310,16 @@ public class FeasibilityQueryHandlerRestControllerIT {
         switch (resultDetail) {
             case SUMMARY -> mockMvc.perform(get(requestUri).with(csrf()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.totalNumberOfPatients").exists())
+                    .andExpect(jsonPath("$.resultSize").exists())
                     .andExpect(jsonPath("$.resultLines", empty()));
             case DETAILED_OBFUSCATED -> mockMvc.perform(get(requestUri).with(csrf()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.totalNumberOfPatients").exists())
+                    .andExpect(jsonPath("$.resultSize").exists())
                     .andExpect(jsonPath("$.resultLines").exists())
                     .andExpect(jsonPath("$.resultLines[0].siteName", startsWith("foobar")));
             case DETAILED -> mockMvc.perform(get(requestUri).with(csrf()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.totalNumberOfPatients").exists())
+                    .andExpect(jsonPath("$.resultSize").exists())
                     .andExpect(jsonPath("$.resultLines").exists())
                     .andExpect(jsonPath("$.resultLines[0].siteName", not(startsWith("foobar"))));
         }
@@ -523,11 +523,11 @@ public class FeasibilityQueryHandlerRestControllerIT {
     @NotNull
     private static QueryResult createTestQueryResult(QueryHandlerService.ResultDetail resultDetail) {
         List<QueryResultLine> queryResultLines;
-        long totalNumberOfPatients;
+        long resultSize;
 
         if (resultDetail == QueryHandlerService.ResultDetail.SUMMARY) {
-            queryResultLines = List.of();
-            totalNumberOfPatients = 999L;
+          queryResultLines = List.of();
+          resultSize = 999L;
         } else {
             var resultLines = List.of(
                     ResultLine.builder()
@@ -554,12 +554,12 @@ public class FeasibilityQueryHandlerRestControllerIT {
                             .build())
                     .toList();
 
-            totalNumberOfPatients = queryResultLines.stream().map(QueryResultLine::numberOfPatients).reduce(0L, Long::sum);
+          resultSize = queryResultLines.stream().map(QueryResultLine::numberOfPatients).reduce(0L, Long::sum);
         }
 
         return QueryResult.builder()
                 .queryId(1L)
-                .totalNumberOfPatients(totalNumberOfPatients)
+                .resultSize(resultSize)
                 .resultLines(queryResultLines)
                 .build();
     }
@@ -595,7 +595,7 @@ public class FeasibilityQueryHandlerRestControllerIT {
 
         return QueryResult.builder()
                 .queryId(1L)
-                .totalNumberOfPatients(queryResultLines.stream().map(QueryResultLine::numberOfPatients).reduce(0L, Long::sum))
+                .resultSize(queryResultLines.stream().map(QueryResultLine::numberOfPatients).reduce(0L, Long::sum))
                 .resultLines(queryResultLines)
                 .build();
     }


### PR DESCRIPTION
…{queryId}

- mark GET /query/data/{queryId} as deprecated
- return lastModified timestamp in iso8601 format instead of sql timestamp format
- rename 'totalNumberOfPatients' to 'resultSize' in feasibility queries