### PR TITLE
#771 - Add extra variable for internal polling limit vs external (ui) polling limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If the number of total results is below the threshold, no result will be provide
 | PRIVACY_QUOTA_SOFT_CREATE_INTERVAL                     | (see description above)                                                                                                                                |         | `PT1M`  |
 | PRIVACY_QUOTA_HARD_CREATE_AMOUNT                       | Amount of queries a user can create in the interval defined in _PRIVACY_QUOTA_HARD_CREATE_INTERVAL_ before being blacklisted.                          |         | `50`    |
 | PRIVACY_QUOTA_HARD_CREATE_INTERVAL                     | (see description above)                                                                                                                                |         | `P7D`   |
-| PRIVACY_QUOTA_READ_SUMMARY_POLLINGINTERVAL             | Interval in which a user can read the summary query result endpoint.                                                                                   |         | `PT10S` |
+| PRIVACY_QUOTA_READ_SUMMARY_POLLINGINTERVAL             | Interval in which a user can read the summary query result endpoint.                                                                                   |         | `PT5S`  |
 | PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_POLLINGINTERVAL | Interval in which a user can read the detailed obfuscated query result endpoint.                                                                       |         | `PT10S` |
 | PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_AMOUNT          | Amount of times a user can create a distinct detailed obfuscated result in the interval defined in _PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_INTERVAL _. |         | `10`    |
 | PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_INTERVAL        | (see description above)                                                                                                                                |         | `PT3S`  |
@@ -159,12 +159,13 @@ To configure the location of the external service, use the following parameters.
 There are a few variables that are not used in the backend itself, but are forwarded to the frontend if requested.
 
 
-| EnvVar                     | Description                                                      | Example           | Default                                                                                                         |
-|----------------------------|------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------|
-| PT_CCDL_VERSION            | The used version of the Clinical Cohort Definition Language      | ``                | `unknown`                                                                                                       |
-| PT_PORTAL_LINK             | URL to the portal page                                           | `https://foo.bar` | `https://antrag.forschen-fuer-gesundheit.de`                                                                    |
-| PT_DSE_PATIENT_PROFILE_URL | URL of the patient profile used in data selection and extraction | `foo,bar,baz`     | `https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert` |  
-| PT_POLLING_TIME_UI         | How long should the UI poll for a result                         | `PT10S`           | `PT1M`                                                                                                          |
+| EnvVar                     | Description                                                                                                        | Example           | Default                                                                                                         |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------|
+| PT_CCDL_VERSION            | The used version of the Clinical Cohort Definition Language                                                        | ``                | `unknown`                                                                                                       |
+| PT_PORTAL_LINK             | URL to the portal page                                                                                             | `https://foo.bar` | `https://antrag.forschen-fuer-gesundheit.de`                                                                    |
+| PT_DSE_PATIENT_PROFILE_URL | URL of the patient profile used in data selection and extraction                                                   | `foo,bar,baz`     | `https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert` |  
+| PT_POLLING_TIME_UI         | How long should the UI poll for a result                                                                           | `PT10S`           | `PT1M`                                                                                                          |
+| PT_POLLING_SUMMARY         | How often should the UI poll for summary results. Must be longer than `PRIVACY_QUOTA_READ_SUMMARY_POLLINGINTERVAL`  | `PT20S`           | `PT10S`                                                                                                         |
 
 ## Support for self-signed certificates
 

--- a/src/main/java/de/medizininformatikinitiative/dataportal/backend/settings/SettingsController.java
+++ b/src/main/java/de/medizininformatikinitiative/dataportal/backend/settings/SettingsController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 @RestController
@@ -31,7 +33,10 @@ public class SettingsController {
   private String readResultDetailedObfuscatedPollingInterval;
 
   @Value("${app.privacy.quota.read.resultSummary.pollingInterval}")
-  private String readResultSummaryPollingInterval = "PT20S";
+  private String readResultSummaryPollingInterval = "PT5S";
+
+  @Value("${passthrough.pollingSummary}")
+  private String passthroughPollingSummary = "PT10S";
 
   @Value("${passthrough.portalLink}")
   private String portalLink;
@@ -54,9 +59,24 @@ public class SettingsController {
 
   @GetMapping("/.settings")
   public Map<String, Object> getSettings() {
+    Duration backendPollingSummaryLimit;
+    Duration uiPollingSummaryLimit;
+    try {
+      backendPollingSummaryLimit = Duration.parse(readResultSummaryPollingInterval);
+    } catch (DateTimeParseException e) {
+      backendPollingSummaryLimit = Duration.ofSeconds(5);
+    }
+    try {
+      uiPollingSummaryLimit = Duration.parse(passthroughPollingSummary);
+    } catch (DateTimeParseException e) {
+      uiPollingSummaryLimit = Duration.ofSeconds(10);
+    }
+    var exposedPollingSummaryLimit =
+        backendPollingSummaryLimit.compareTo(uiPollingSummaryLimit) < 0 ? uiPollingSummaryLimit : backendPollingSummaryLimit.plusSeconds(5);
+
     return Map.ofEntries(
         Map.entry(KEY_REST_API_PATH, WebSecurityConfig.PATH_API),
-        Map.entry(KEY_READ_RESULT_SUMMARY_POLLING_INTERVAL, readResultSummaryPollingInterval),
+        Map.entry(KEY_READ_RESULT_SUMMARY_POLLING_INTERVAL, exposedPollingSummaryLimit.toString()),
         Map.entry(KEY_READ_RESULT_DETAILED_OBFUSCATED_POLLING_INTERVAL, readResultDetailedObfuscatedPollingInterval),
         Map.entry(KEY_READ_RESULT_DETAILED_OBFUSCATED_AMOUNT, readResultDetailedObfuscatedAmount),
         Map.entry(KEY_READ_RESULT_DETAILED_OBFUSCATED_INTERVAL, readResultDetailedObfuscatedInterval),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,7 +146,7 @@ app:
           interval: ${PRIVACY_QUOTA_HARD_CREATE_INTERVAL:P1W}
       read:
         resultSummary:
-          pollingInterval: ${PRIVACY_QUOTA_READ_SUMMARY_POLLINGINTERVAL:PT10S}
+          pollingInterval: ${PRIVACY_QUOTA_READ_SUMMARY_POLLINGINTERVAL:PT5S}
         resultDetailedObfuscated:
           pollingInterval: ${PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_POLLINGINTERVAL:PT10S}
           amount: ${PRIVACY_QUOTA_READ_DETAILED_OBFUSCATED_AMOUNT:3}
@@ -156,6 +156,7 @@ passthrough:
   portalLink: ${PT_PORTAL_LINK:https://antrag.forschen-fuer-gesundheit.de}
   dsePatientProfileUrl: ${PT_DSE_PATIENT_PROFILE_URL:https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert}
   pollingTimeUi: ${PT_POLLING_TIME_UI:PT1M}
+  pollingSummary: ${PT_POLLING_SUMMARY:PT10S}
 logging:
   level:
     org.hibernate: ${LOG_LEVEL_SQL:warn}


### PR DESCRIPTION
- add PT_POLLING_SUMMARY variable that allows to configure which value is sent to the ui as polling time for result summaries
- in case this value is lower than what the backend allows, it will automatically be set to the backend value + 5 seconds