### PR TITLE
#1007 - Change elastic search queries to include ngram field

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/CodeableConceptService.java
+++ b/src/main/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/CodeableConceptService.java
@@ -33,6 +33,7 @@ import java.util.*;
 @ConditionalOnExpression("${app.elastic.enabled}")
 public class CodeableConceptService {
   public static final String FIELD_NAME_TERMCODE_KEYWORD = "termcode.code.keyword";
+  public static final String FIELD_NAME_TERMCODE_NGRAM = "termcode.code.ngram";
   public static final String FILTER_KEY_VALUE_SETS = "value_sets";
   private static final UUID NAMESPACE_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
   private ElasticsearchOperations operations;

--- a/src/test/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/CodeableConceptServiceIT.java
+++ b/src/test/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/CodeableConceptServiceIT.java
@@ -39,7 +39,7 @@ public class CodeableConceptServiceIT {
 
   @Container
   @ServiceConnection
-  public static ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:9.1.4")
+  public static ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:9.4.3")
       .withEnv("discovery.type", "single-node")
       .withEnv("xpack.security.enabled", "false")
       .withReuse(false)

--- a/src/test/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/TerminologyEsServiceIT.java
+++ b/src/test/java/de/medizininformatikinitiative/dataportal/backend/terminology/es/TerminologyEsServiceIT.java
@@ -50,7 +50,7 @@ public class TerminologyEsServiceIT {
 
   @Container
   @ServiceConnection
-  public static ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:9.1.4")
+  public static ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:9.4.3")
       .withEnv("discovery.type", "single-node")
       .withEnv("xpack.security.enabled", "false")
       .withReuse(false)

--- a/src/test/resources/de/medizininformatikinitiative/dataportal/backend/terminology/es/codeable_concept.json
+++ b/src/test/resources/de/medizininformatikinitiative/dataportal/backend/terminology/es/codeable_concept.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_ngram_diff": 49
+    },
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -15,6 +18,29 @@
           "type": "edge_ngram",
           "min_gram": 1,
           "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "ngram_tokenizer_include_punctuation": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
           "token_chars": [
             "letter",
             "digit",
@@ -45,6 +71,20 @@
             "lowercase"
           ]
         },
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
         "lowercase_analyzer": {
           "type": "custom",
           "tokenizer": "whitespace_tokenizer",
@@ -64,6 +104,12 @@
             "fields": {
               "keyword": {
                 "type": "keyword"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
               }
             },
             "analyzer": "edge_ngram_analyzer_include_punctuation",
@@ -72,7 +118,15 @@
           "display": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "system": {
             "type": "text",
@@ -92,20 +146,47 @@
           "original": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "de": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "en": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           }
         }
       }
+    },
+    "_meta": {
+      "version": "v4.1.0"
     }
   }
 }

--- a/src/test/resources/de/medizininformatikinitiative/dataportal/backend/terminology/es/ontology.json
+++ b/src/test/resources/de/medizininformatikinitiative/dataportal/backend/terminology/es/ontology.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_ngram_diff": 49
+    },
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -15,6 +18,29 @@
           "type": "edge_ngram",
           "min_gram": 1,
           "max_gram": 50,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation",
+            "custom"
+          ],
+          "custom_token_chars": [
+            "+-_"
+          ]
+        },
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        },
+        "ngram_tokenizer_include_punctuation": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 25,
           "token_chars": [
             "letter",
             "digit",
@@ -41,6 +67,20 @@
         "edge_ngram_analyzer_include_punctuation": {
           "type": "custom",
           "tokenizer": "edge_ngram_tokenizer_include_punctuation",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer",
+          "filter": [
+            "lowercase"
+          ]
+        },
+        "ngram_analyzer_include_punctuation": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer_include_punctuation",
           "filter": [
             "lowercase"
           ]
@@ -112,17 +152,41 @@
           "original": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "de": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           },
           "en": {
             "type": "text",
             "analyzer": "edge_ngram_analyzer_include_punctuation",
-            "search_analyzer": "lowercase_analyzer"
+            "search_analyzer": "lowercase_analyzer",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "ngram_analyzer_include_punctuation",
+                "search_analyzer": "lowercase_analyzer",
+                "norms": false
+              }
+            }
           }
         }
       },
@@ -182,6 +246,12 @@
         "fields": {
           "keyword": {
             "type": "keyword"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "ngram_analyzer_include_punctuation",
+            "search_analyzer": "lowercase_analyzer",
+            "norms": false
           }
         },
         "analyzer": "edge_ngram_analyzer_include_punctuation",
@@ -210,6 +280,9 @@
       "terminology": {
         "type": "keyword"
       }
+    },
+    "_meta": {
+      "version": "v4.1.0"
     }
   }
 }


### PR DESCRIPTION
This will not work with the current ontology versions. Changes are required that will be suggested to the ontology generator team once this is tested and accepted by the GUI team.

Please find the modified index generation json files attached. Easiest way is to swap them in the current elastic.zip from the ontology release and then use the [elastic search init container with a locally mounted zip file](https://github.com/medizininformatik-initiative/dataportal-es-init#providing-a-local-archive-file-via-mount)


[codeable_concept_index.json](https://github.com/user-attachments/files/29804099/codeable_concept_index.json)
[ontology_index.json](https://github.com/user-attachments/files/29804100/ontology_index.json)

- add .ngram fields and increase boost for current fields