### PR TITLE
Fix CA cert import silently dropping certs on CRLF/no-trailing-newline PEM files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
     branches:
       - master
       - develop
+      - 'support/**'
     tags:
     - v[0-9]+.[0-9]+.[0-9]+**
   pull_request:
     branches:
     - master
     - develop
+    - 'support/**'
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: mvn -Pdownload-ontology -B verify
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         push: false
 
     - name: Run Trivy Vulnerability Scanner
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: security-scan-build:latest
         format: sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,8 @@ if [ ! "${#ca_files[@]}" -eq 0 ]; then
       echo "###   Importing certificates:"
 
       buf=""
-      while IFS= read -r line; do
+      while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
         buf="$buf$line\n"
         if [ "$line" = "-----END CERTIFICATE-----" ]; then
           printf "%b" "$buf" > "$tmp_ca_pem_file"


### PR DESCRIPTION
## Summary
- `docker-entrypoint.sh` splits multi-cert PEM bundles by comparing each line against the literal string `-----END CERTIFICATE-----`. PEM files with CRLF line endings (common for CAs exported from a Windows CA/AD CS) never match because of the trailing `\r`, so the certificate is silently never imported into the truststore.
- Since the resulting truststore contains no public root CAs by design (air-gapped clinic setups), a dropped custom CA means the JVM trusts nothing — causing outbound TLS calls (e.g. to a clinic-local Keycloak) to fail with an untrusted-CA/SSL error, even though the same PEM worked before the line-splitting logic was introduced in v8.3.0 (#780).
- Also fixes a related edge case: a PEM whose last certificate isn't followed by a trailing newline was silently dropped too, since bash's `read` doesn't report success on a final non-newline-terminated line.

## Fix
- Strip a trailing `\r` from each line before comparing it to `-----END CERTIFICATE-----`.
- Add `|| [ -n "$line" ]` to the `while read` loop condition so the last line is still processed when the file has no trailing newline.

## Test plan
- [x] Verified locally with a self-signed test cert in three PEM variants (Unix LF, CRLF, no trailing newline) that the fixed extraction logic detects exactly 1 certificate in all three cases, versus 0 for CRLF and no-trailing-newline files with the current (unfixed) logic.
- [ ] Manual smoke test: mount a CRLF-encoded clinic CA `.pem` into `certs/`, start the container, confirm the cert appears in the "Adding cert" log output and Keycloak login succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)